### PR TITLE
支持SOCKS5代理

### DIFF
--- a/Perf.py
+++ b/Perf.py
@@ -12,7 +12,7 @@ from pixivpy3 import PixivAPI as Sync_papi
 sys.dont_write_bytecode = True
 
 _USERNAME = "userbay"
-_PASSWORD = "userpay"
+_PASSWORD = "UserPay"
 
 saapi = Sync_aapi()
 saapi.login(_USERNAME, _PASSWORD)

--- a/demo/bug_demo_pypi_me.py
+++ b/demo/bug_demo_pypi_me.py
@@ -8,7 +8,7 @@ from pixivpy_async import PixivAPI
 sys.dont_write_bytecode = True
 
 _USERNAME = "userbay"
-_PASSWORD = "userpay"
+_PASSWORD = "UserPay"
 
 
 async def papi_me(api):

--- a/demo/bug_demo_pypi_users.py
+++ b/demo/bug_demo_pypi_users.py
@@ -8,7 +8,7 @@ from pixivpy_async import PixivAPI
 sys.dont_write_bytecode = True
 
 _USERNAME = "userbay"
-_PASSWORD = "userpay"
+_PASSWORD = "UserPay"
 
 
 async def papi_user(api):

--- a/demo/demo_api_proxy.py
+++ b/demo/demo_api_proxy.py
@@ -5,7 +5,7 @@ import uuid
 from pixivpy_async import *
 
 _USERNAME = "userbay"
-_PASSWORD = "userpay"
+_PASSWORD = "UserPay"
 
 
 async def _main(aapi):

--- a/demo/demo_appapi_auth_api.py
+++ b/demo/demo_appapi_auth_api.py
@@ -8,7 +8,7 @@ from pixivpy_async import AppPixivAPI
 sys.dont_write_bytecode = True
 
 _USERNAME = "userbay"
-_PASSWORD = "userpay"
+_PASSWORD = "UserPay"
 
 
 async def appapi_auth_api(aapi):

--- a/demo/demo_appapi_illust.py
+++ b/demo/demo_appapi_illust.py
@@ -8,7 +8,7 @@ from pixivpy_async import AppPixivAPI
 sys.dont_write_bytecode = True
 
 _USERNAME = "userbay"
-_PASSWORD = "userpay"
+_PASSWORD = "UserPay"
 
 
 async def appapi_illust(aapi):

--- a/demo/demo_appapi_ranking.py
+++ b/demo/demo_appapi_ranking.py
@@ -8,7 +8,7 @@ from pixivpy_async import AppPixivAPI
 sys.dont_write_bytecode = True
 
 _USERNAME = "userbay"
-_PASSWORD = "userpay"
+_PASSWORD = "UserPay"
 
 
 async def appapi_ranking(aapi):

--- a/demo/demo_appapi_recommend.py
+++ b/demo/demo_appapi_recommend.py
@@ -8,7 +8,7 @@ from pixivpy_async import AppPixivAPI
 sys.dont_write_bytecode = True
 
 _USERNAME = "userbay"
-_PASSWORD = "userpay"
+_PASSWORD = "UserPay"
 
 
 async def appapi_recommend(aapi):

--- a/demo/demo_appapi_search.py
+++ b/demo/demo_appapi_search.py
@@ -8,7 +8,7 @@ from pixivpy_async import AppPixivAPI
 sys.dont_write_bytecode = True
 
 _USERNAME = "userbay"
-_PASSWORD = "userpay"
+_PASSWORD = "UserPay"
 
 
 async def appapi_search(aapi):

--- a/demo/demo_appapi_search_with_filter.py
+++ b/demo/demo_appapi_search_with_filter.py
@@ -8,7 +8,7 @@ from pixivpy_async import AppPixivAPI
 sys.dont_write_bytecode = True
 
 _USERNAME = "userbay"
-_PASSWORD = "userpay"
+_PASSWORD = "UserPay"
 
 
 async def appapi_search(aapi):

--- a/demo/demo_appapi_users.py
+++ b/demo/demo_appapi_users.py
@@ -8,7 +8,7 @@ from pixivpy_async import AppPixivAPI
 sys.dont_write_bytecode = True
 
 _USERNAME = "userbay"
-_PASSWORD = "userpay"
+_PASSWORD = "UserPay"
 
 
 async def appapi_users(aapi):

--- a/demo/demo_download_async.py
+++ b/demo/demo_download_async.py
@@ -6,7 +6,7 @@ import os
 from pixivpy_async import AppPixivAPI
 
 _USERNAME = "userbay"
-_PASSWORD = "userpay"
+_PASSWORD = "UserPay"
 
 
 async def _main(aapi):

--- a/demo/demo_papi_base.py
+++ b/demo/demo_papi_base.py
@@ -8,7 +8,7 @@ from pixivpy_async import PixivAPI
 sys.dont_write_bytecode = True
 
 _USERNAME = "userbay"
-_PASSWORD = "userpay"
+_PASSWORD = "UserPay"
 
 
 async def papi_base(api):

--- a/demo/demo_papi_others.py
+++ b/demo/demo_papi_others.py
@@ -8,7 +8,7 @@ from pixivpy_async import PixivAPI
 sys.dont_write_bytecode = True
 
 _USERNAME = "userbay"
-_PASSWORD = "userpay"
+_PASSWORD = "UserPay"
 
 
 async def papi_ranking(api):

--- a/demo/example_tag_translations.py
+++ b/demo/example_tag_translations.py
@@ -6,7 +6,7 @@ from datetime import *
 
 # change _USERNAME,_PASSWORD first!
 _USERNAME = "userbay"
-_PASSWORD = "userpay"
+_PASSWORD = "UserPay"
 
 
 def main():

--- a/demo/login_env.py
+++ b/demo/login_env.py
@@ -5,7 +5,7 @@ from pixivpy_async import AppPixivAPI, PixivClient
 from pixivpy_async.sync import AppPixivAPI as SAAPI
 
 _USERNAME = 'userbay'
-_PASSWORD = 'userpay'
+_PASSWORD = 'UserPay'
 
 
 def test0():

--- a/pixivpy_async/client.py
+++ b/pixivpy_async/client.py
@@ -1,10 +1,46 @@
 import asyncio
 import aiohttp
+from aiohttp_socks import ProxyType, ProxyConnector, ChainProxyConnector
 
 
 class PixivClient:
-    def __init__(self, limit=30, timeout=10, env=False, internal=False):
-        self.conn = aiohttp.TCPConnector(limit_per_host=limit)
+    def __init__(self, limit=30, timeout=10, env=False, internal=False, proxy=None):
+        """
+            When 'env' is True and 'proxy' is None, possible proxies will be
+            obtained automatically (wrong proxy may be obtained).
+
+            When 'proxy' is not None, it will force the proxy to be used and
+            'env' will have no effect.
+
+            proxy <str> is used for a single proxy with a url:
+                'socks5://user:password@127.0.0.1:1080'
+
+            proxy <dict> is used for a single proxy with a dict:
+                proxy_dict = {
+                    'proxy_type': ProxyType.SOCKS5,
+                    'host': '127.0.0.1',
+                    'port': 1080,
+                    'rdns': True
+                }
+
+            proxy <list> is used for proxy chaining with a list of urls:
+                [
+                    'socks5://user:password@127.0.0.1:1080',
+                    'socks4://127.0.0.1:1081',
+                    'http://user:password@127.0.0.1:3128',
+                ]
+
+        """
+
+        if type(proxy) is str:
+            self.conn = ProxyConnector.from_url(proxy, limit_per_host=limit)
+        if type(proxy) is dict:
+            self.conn = ProxyConnector(**proxy, limit_per_host=limit)
+        if type(proxy) is list:
+            self.conn = ChainProxyConnector.from_urls(proxy, limit_per_host=limit)
+        if not proxy:
+            self.conn = aiohttp.TCPConnector(limit_per_host=limit)
+
         self.internal = internal
         self.client = aiohttp.ClientSession(
             connector=self.conn,

--- a/pixivpy_async/client.py
+++ b/pixivpy_async/client.py
@@ -1,6 +1,6 @@
 import asyncio
 import aiohttp
-from aiohttp_socks import ProxyType, ProxyConnector, ChainProxyConnector
+from aiohttp_socks import ProxyConnector
 
 
 class PixivClient:
@@ -15,29 +15,12 @@ class PixivClient:
             proxy <str> is used for a single proxy with a url:
                 'socks5://user:password@127.0.0.1:1080'
 
-            proxy <dict> is used for a single proxy with a dict:
-                proxy_dict = {
-                    'proxy_type': ProxyType.SOCKS5,
-                    'host': '127.0.0.1',
-                    'port': 1080,
-                    'rdns': True
-                }
-
-            proxy <list> is used for proxy chaining with a list of urls:
-                [
-                    'socks5://user:password@127.0.0.1:1080',
-                    'socks4://127.0.0.1:1081',
-                    'http://user:password@127.0.0.1:3128',
-                ]
+            If you want to use proxy chaining, read https://github.com/romis2012/aiohttp-socks.
 
         """
 
-        if isinstance(proxy, str):
+        if proxy:
             self.conn = ProxyConnector.from_url(proxy, limit_per_host=limit)
-        elif isinstance(proxy, dict):
-            self.conn = ProxyConnector(**proxy, limit_per_host=limit)
-        elif isinstance(proxy, list):
-            self.conn = ChainProxyConnector.from_urls(proxy, limit_per_host=limit)
         else:
             self.conn = aiohttp.TCPConnector(limit_per_host=limit)
 

--- a/pixivpy_async/client.py
+++ b/pixivpy_async/client.py
@@ -32,13 +32,13 @@ class PixivClient:
 
         """
 
-        if type(proxy) is str:
+        if isinstance(proxy, str):
             self.conn = ProxyConnector.from_url(proxy, limit_per_host=limit)
-        if type(proxy) is dict:
+        elif isinstance(proxy, dict):
             self.conn = ProxyConnector(**proxy, limit_per_host=limit)
-        if type(proxy) is list:
+        elif isinstance(proxy, list):
             self.conn = ChainProxyConnector.from_urls(proxy, limit_per_host=limit)
-        if not proxy:
+        else:
             self.conn = aiohttp.TCPConnector(limit_per_host=limit)
 
         self.internal = internal

--- a/pixivpy_async/net.py
+++ b/pixivpy_async/net.py
@@ -9,9 +9,9 @@ retryable_error = asyncio.TimeoutError, aiohttp.ClientError, aiohttp.ServerTimeo
 
 
 class ClientManager:
-    def __init__(self, s, env):
+    def __init__(self, s, env, proxy):
         if s is None:
-            self.session = PixivClient(internal=True, env=env)
+            self.session = PixivClient(internal=True, env=env, proxy=proxy)
         else:
             self.session = s
 
@@ -28,14 +28,15 @@ class ClientManager:
 
 
 class Net(object):
-    def __init__(self, client=None, env=False, **requests_kwargs):
+    def __init__(self, client=None, env=False, proxy=None, **requests_kwargs):
         self.session = client
         self.env = env
+        self.proxy = proxy
         self.requests_kwargs = requests_kwargs
 
     @retry(*retryable_error, retries=10, cooldown=random.randint(1, 3))
     async def down(self, _url, _referer):
-        async with ClientManager(self.session, self.env) as session:
+        async with ClientManager(self.session, self.env, self.proxy) as session:
             async with session.get(_url, headers={'Referer': _referer}, **self.requests_kwargs) as res:
                 c = await res.read()
                 t = res.content_type
@@ -45,7 +46,7 @@ class Net(object):
 
     @retry(*retryable_error, retries=10, cooldown=random.randint(1, 3))
     async def auth(self, _url, _headers, _data):
-        async with ClientManager(self.session, self.env) as session:
+        async with ClientManager(self.session, self.env, self.proxy) as session:
             async with session.post(_url, headers=_headers, data=_data, **self.requests_kwargs) as res:
                 r, b, q = await res.json(), res.status in [200, 301, 302], res.status
 
@@ -54,7 +55,7 @@ class Net(object):
 
     @retry(*retryable_error, retries=10, cooldown=random.randint(1, 3))
     async def fetch(self, _url, _headers, _params):
-        async with ClientManager(self.session, self.env) as session:
+        async with ClientManager(self.session, self.env, self.proxy) as session:
             async with session.get(_url, headers=_headers, params=_params, **self.requests_kwargs) as res:
                 q = await res.json()
 
@@ -63,7 +64,7 @@ class Net(object):
 
     @retry(*retryable_error, retries=10, cooldown=random.randint(1, 3))
     async def post(self, _url, _data, _headers, _params):
-        async with ClientManager(self.session, self.env) as session:
+        async with ClientManager(self.session, self.env, self.proxy) as session:
             async with session.post(_url, data=_data, headers=_headers, params=_params, **self.requests_kwargs) as res:
                 r = await res.json()
 
@@ -72,7 +73,7 @@ class Net(object):
 
     @retry(*retryable_error, retries=10, cooldown=random.randint(1, 3))
     async def delete(self, _url, _headers, _params):
-        async with ClientManager(self.session, self.env) as session:
+        async with ClientManager(self.session, self.env, self.proxy) as session:
             async with session.delete(_url, headers=_headers, params=_params, **self.requests_kwargs) as res:
                 q = await res.json()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 aiohttp[speedups]
 aiofiles
+aiohttp-socks

--- a/test.py
+++ b/test.py
@@ -14,7 +14,7 @@ from pixivpy_async.sync import *
 sys.dont_write_bytecode = True
 
 _USERNAME = "userbay"
-_PASSWORD = "userpay"
+_PASSWORD = "UserPay"
 
 aapi = AppPixivAPI()
 papi = PixivAPI()


### PR DESCRIPTION
找了相关的库，尝试支持了一下 SOCKS5，以及支持在初始化`PixivClient`的时候手动指定代理链接参数`proxy`来避免使用 `env=True` 自动检测可能产生的失误，本地测试通过。
需要 [`aiohttp_socks` ](https://github.com/romis2012/aiohttp-socks) 库支持。